### PR TITLE
Support `antigen bundle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,23 @@ You can run npm/yarn/pnpm/bun with same command!
 
 ## Installation
 
+### Using Zinit
+
+```shell
+zinit load azu/ni.zsh@main
+```
+### Using Antigen
+
+```shell
+antigen bundle azu/ni.zsh@main
+```
+
+### Manually
+
 ```shell
 curl https://raw.githubusercontent.com/azu/ni.zsh/main/ni.zsh > ni.zsh
 source ni.zsh
 ```
-
-- [ ] correct distribution
 
 ## Supports
 

--- a/ni.plugin.zsh
+++ b/ni.plugin.zsh
@@ -1,0 +1,1 @@
+source ${0:h}/ni.zsh


### PR DESCRIPTION
Enable loading of this plugin from Antigen.

## References

https://github.com/olets/zsh-abbr/blob/main/zsh-abbr.plugin.zsh
