### PR TITLE
fix: README to work with zinit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can run npm/yarn/pnpm/bun with same command!
 ### Using Zinit
 
 ```shell
-zinit load azu/ni.zsh@main
+zinit load azu/ni.zsh
 ```
 ### Using Antigen
 


### PR DESCRIPTION
I tried to install ni with zinit but it failed, so I modified the README.

## before
```shell
~ ❯❯❯ zinit load azu/ni.zsh@main

Downloading azu/ni.zsh@main…
Cloning into '/home/<name>/.local/share/zinit/plugins/azu---ni.zsh@main'...
remote: Repository not found.
fatal: repository 'https://github.com/azu/ni.zsh@main/' not found

Clone failed (code: 128).
```

## after
```shell
~ ❯❯❯ zinit load azu/ni.zsh

Downloading azu/ni.zsh…
Cloning into '/home/<name>/.local/share/zinit/plugins/azu---ni.zsh'...
⠙ ███████████ OBJ: 100, PACK: 0/51, COMPR: 100%
Note: Compiling: ni.plugin.zsh… OK.
```