### PR TITLE
fix: README to work with sheldon

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ zinit load azu/ni.zsh
 antigen bundle azu/ni.zsh@main
 ```
 
+### Using sheldon
+
+```toml
+[plugins.ni]
+github = "azu/ni.zsh"
+```
+
 ### Manually
 
 ```shell


### PR DESCRIPTION
I added an example of [sheldon](https://github.com/rossmacarthur/sheldon).

ref: https://github.com/odanado/dotfiles/blob/5eed207ed221b8289afa2714d83d798065dca1ff/config/sheldon/plugins.toml#L50-L51