### PR TITLE
fix: remove duplicated risks

### DIFF
--- a/ni.zsh
+++ b/ni.zsh
@@ -142,7 +142,7 @@ function ni-assertPackageBySocket() {
     --url "https://api.socket.dev/v0/npm/${pkg}/${version}/issues" \
     --header 'accept: application/json' \
     --header "authorization: Basic ${bearerToken}" \
-    | jq -r '[.[] | select(.value.category == "supplyChainRisk") | {severity: .value.severity, type: .type}] | sort_by([.severity == "low", .severity == "middle", .severity == "high", .severity == "critical"]) | map("* [\(.severity)] \(.type) - https://socket.dev/npm/issue/\(.type)") | join("\n")')
+    | jq -r '[.[] | select(.value.category == "supplyChainRisk") | {severity: .value.severity, type: .type}] | sort_by(.severity) | map("* [\(.severity)] \(.type) - https://socket.dev/npm/issue/\(.type)") | unique | join("\n")')
     # jq filter is following logic
     # ```js
     # const message = test.filter((item) => {
@@ -155,6 +155,9 @@ function ni-assertPackageBySocket() {
     # }).map((item) => {
     #   // [value.severity] [type] - https://socket.dev/npm/issue/${type}
     #   return `* ${item.value.severity} ${item.type} - https://socket.dev/npm/issue/${item.type}`;
+    # }).filter((item, array) => {
+    #   // remove duplicated
+    #   return array.indexOf(item) === array.lastIndexOf(item);
     # });
     # ```
     echo -e "\033[31m$riskMessage\033[0m"


### PR DESCRIPTION
Add `| unique` to riskMessage.

## Test Plan

```
ni-assertPackageBySocket @usps/core-clients@235.2.11
```