### PR TITLE
fix: choose bun if both bun.lockb and yarn.lock exist

### DIFF
--- a/ni.zsh
+++ b/ni.zsh
@@ -39,12 +39,13 @@ function ni-getPackageManager() {
   # detect package manager via lock file
   if [ -f "pnpm-lock.yaml" ]; then
     echo "pnpm"
+  elif [ -f "bun.lockb" ]; then
+    # choose bun if both bun.lockb and yarn.lock exist
+    echo "bun"
   elif [ -f "yarn.lock" ]; then
     echo "yarn"
   elif [ -f "package-lock.json" ]; then
     echo "npm"
-  elif [ -f "bun.lockb" ]; then
-    echo "bun"
   else
     echo "npm"
   fi

--- a/ni.zsh
+++ b/ni.zsh
@@ -41,6 +41,8 @@ function ni-getPackageManager() {
     echo "pnpm"
   elif [ -f "bun.lockb" ]; then
     # choose bun if both bun.lockb and yarn.lock exist
+    # bun generate yarn.lock and bun.lockb when print=yarn is set
+    # https://bun.sh/docs/install/lockfile
     echo "bun"
   elif [ -f "yarn.lock" ]; then
     echo "yarn"


### PR DESCRIPTION
Since bun's lockfile is binary, some users set `print="yarn"` to output a `yarn.lock` file. Therefore, there are cases where both `bun.lockb` and `yarn.lock` exist. Currently, ni chooses yarn in this situation. However, in this case, I would prefer that bun be chosen.

In this PR, even if `yarn.lock` exists, bun will be chosen by checking for `bun.lockb` first.

https://bun.sh/docs/install/lockfile
