### PR TITLE
feat(deno): support `ni upgrade` and `ni upgrade-interactive`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ source /path/to/ni.zsh
 - [yarn-berry](https://yarnpkg.com/) (yarn v2+)
 - [pnpm](https://pnpm.js.org/)
 - [bun](https://bun.sh/)
+- [deno](https://deno.com/)
 
 ## Requirements
 
@@ -85,8 +86,8 @@ ni dlx <pkg>            -- download package and execute command
 | `ni remove <pkg>`        | `npm uninstall`   | `yarn remove`              | `yarn remove`              | `pnpm remove`    | `bun remove`   | `deno uninstall` |
 | `ni run <script>`        | `npm run`         | `yarn run`                 | `yarn run`                 | `pnpm run`       | `bun run`      | `deno run` |
 | `ni test`                | `npm run test`    | `yarn run test`            | `yarn run test`            | `pnpm run test`  | `bun run test` | `deno run test` |
-| `ni upgrade`             | `npm upgrade`     | `yarn upgrade`             | `yarn up`                  | `pnpm update`    | `bun update`              | ○              |
-| `ni upgrade-interactive` | `npm-check`**^1** | `yarn up --interactive "*"` | `yarn upgrade-interactive` | `pnpm update -i` | ○              | ○              |
+| `ni upgrade`             | `npm upgrade`     | `yarn upgrade`             | `yarn up`                  | `pnpm update`    | `bun update`              | `deno outdated --update` |
+| `ni upgrade-interactive` | `npm-check`**^1** | `yarn up --interactive "*"` | `yarn upgrade-interactive` | `pnpm update -i` | ○              | `deno outdated --update --interactive` |
 | `ni exec <command>`      | `npm exec --no`   | `yarn <command>`           | `yarn exec`                | `pnpm exec`      | `bunx`         | ○             |
 | `ni dlx <pkg>`       | `npx`             | `npx`                      | `yarn dlx`                 | `pnpm dlx`       | `bunx`         | ○             |
 

--- a/ni.zsh
+++ b/ni.zsh
@@ -407,12 +407,12 @@ function ni-run(){
 }
 
 # ni upgrade - upgrade package
-## (not available for bun)
 ## npm upgrade
 ## yarn upgrade (Yarn 1)
 ## yarn up (Yarn Berry)
 ## pnpm update
-## [ ] deno
+## bun update
+## deno outdated --update
 function ni-upgrade(){
   local manager
   manager=$(ni-getPackageManager)
@@ -435,7 +435,7 @@ function ni-upgrade(){
       ni-echoRun bun update $packageName
       ;;
     deno)
-      echo "deno does not support upgrade command"
+      ni-echoRun deno outdated --update $packageName
       ;;
   esac
 }
@@ -462,7 +462,8 @@ function ni-upgrade-interactive(){
       echo "bun does not support upgrade interactive command"
       ;;
     deno)
-      echo "deno does not support upgrade interactive command"
+      # https://github.com/denoland/deno/releases/tag/v2.2.0
+      ni-echoRun deno outdated --update --interactive --latest
       ;;
   esac
 }


### PR DESCRIPTION
This PR adds Deno support for `ni upgrade` and `ni upgrade-interactive`.

- `ni upgrade` uses `deno outdated --update` to upgrade the specified dependencies.
- `ni upgrade-interactive` uses `deno outdated --update --interactive --latest` to upgrade dependencies interactively. The `--latest` is specified to align behavior with [`yarn`](https://github.com/azu/ni.zsh/blob/v1.5.0/ni.zsh#L452-L453) and [`pnpm`](https://github.com/azu/ni.zsh/blob/v1.5.0/ni.zsh#L458-L460).