### PR TITLE
feat(deno): add `--npm` flag when running `deno add` command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,12 +40,12 @@ jobs:
           if [ "${{ matrix.package-manager }}" = "deno" ]; then
             # Add dependencies first
             ni add jsr:@std/path@0.220.1
-            ni add npm:chalk@5.3.0
+            ni add chalk@5.3.0
             # Run tests and scripts
             ni test
             ni run main
             # Remove packages
-            ni remove npm:chalk
+            ni remove chalk
             ni remove jsr:@std/path
           else
             ni

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ source /path/to/ni.zsh
 - [yarn-berry](https://yarnpkg.com/) (yarn v2+)
 - [pnpm](https://pnpm.js.org/)
 - [bun](https://bun.sh/)
-- [deno](https://deno.com/)
+- [deno](https://deno.com/) (deno v2.3+)
 
 ## Requirements
 
@@ -82,7 +82,7 @@ ni dlx <pkg>            -- download package and execute command
 | ni                       | npm               | yarn                       | yarn-berry                 | pnpm             | bun            | deno |
 |--------------------------|-------------------|----------------------------|----------------------------|------------------|----------------| ---- |
 | `ni`                     | `npm install`     | `yarn install`             | `yarn install`             | `pnpm install`   | `bun install`  | `deno install` |
-| `ni add <pkg>`           | `npm install`     | `yarn add`                 | `yarn add`                 | `pnpm add`       | `bun add`      | `deno add` |
+| `ni add <pkg>`           | `npm install`     | `yarn add`                 | `yarn add`                 | `pnpm add`       | `bun add`      | `deno add --npm` |
 | `ni remove <pkg>`        | `npm uninstall`   | `yarn remove`              | `yarn remove`              | `pnpm remove`    | `bun remove`   | `deno uninstall` |
 | `ni run <script>`        | `npm run`         | `yarn run`                 | `yarn run`                 | `pnpm run`       | `bun run`      | `deno run` |
 | `ni test`                | `npm run test`    | `yarn run test`            | `yarn run test`            | `pnpm run test`  | `bun run test` | `deno run test` |

--- a/ni.zsh
+++ b/ni.zsh
@@ -364,7 +364,7 @@ function ni-add() {
       ni-echoRun bun add $flag
       ;;
     deno)
-      ni-echoRun deno add $flag
+      ni-echoRun deno add --npm $flag
       ;;
   esac
 }


### PR DESCRIPTION
This PR changes the behavior of the `ni add` so that the `--npm` option is specified when the `deno add` is executed. This change allows users to install npm packages without the `npm:` prefix.

> [!WARNING]
> This change introduces a dependency on [Deno v2.3](https://deno.com/blog/v2.3) or later for the `ni add` command to work correctly with Deno projects. Users with older Deno versions will need to update their Deno installation to use this functionality.

Closes #29.