### PR TITLE
feat: add `ni ci` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ source /path/to/ni.zsh
 
 ```sh
 ni                      -- install current package.json
+ni ci                   -- install with frozen lockfile (equivalent to npm ci)
 ni add <pkg>            -- add package
 ni remove <pkg>         -- remove package
 ni run <script>         -- run scripts
@@ -79,17 +80,18 @@ ni dlx <pkg>            -- download package and execute command
 
 ## Command Table
 
-| ni                       | npm               | yarn                       | yarn-berry                 | pnpm             | bun            | deno |
-|--------------------------|-------------------|----------------------------|----------------------------|------------------|----------------| ---- |
-| `ni`                     | `npm install`     | `yarn install`             | `yarn install`             | `pnpm install`   | `bun install`  | `deno install` |
-| `ni add <pkg>`           | `npm install`     | `yarn add`                 | `yarn add`                 | `pnpm add`       | `bun add`      | `deno add --npm` |
-| `ni remove <pkg>`        | `npm uninstall`   | `yarn remove`              | `yarn remove`              | `pnpm remove`    | `bun remove`   | `deno uninstall` |
-| `ni run <script>`        | `npm run`         | `yarn run`                 | `yarn run`                 | `pnpm run`       | `bun run`      | `deno run` |
-| `ni test`                | `npm run test`    | `yarn run test`            | `yarn run test`            | `pnpm run test`  | `bun run test` | `deno run test` |
-| `ni upgrade`             | `npm upgrade`     | `yarn upgrade`             | `yarn up`                  | `pnpm update`    | `bun update`              | `deno outdated --update` |
-| `ni upgrade-interactive` | `npm-check`**^1** | `yarn up --interactive "*"` | `yarn upgrade-interactive` | `pnpm update -i` | ○              | `deno outdated --update --interactive` |
-| `ni exec <command>`      | `npm exec --no`   | `yarn <command>`           | `yarn exec`                | `pnpm exec`      | `bunx`         | ○             |
-| `ni dlx <pkg>`       | `npx`             | `npx`                      | `yarn dlx`                 | `pnpm dlx`       | `bunx`         | `deno x`      |
+| ni                       | npm                              | yarn                             | yarn-berry                 | pnpm                             | bun                                | deno                                   |
+|--------------------------|----------------------------------|----------------------------------|----------------------------|----------------------------------|------------------------------------|----------------------------------------|
+| `ni`                     | `npm install`                    | `yarn install`                   | `yarn install`             | `pnpm install`                   | `bun install`                      | `deno install`                         |
+| `ni ci`                  | `npm ci`                         | `yarn install --frozen-lockfile` | `yarn install --immutable` | `pnpm install --frozen-lockfile` | `bun install --frozen-lockfile`    | `deno install --frozen`                |
+| `ni add <pkg>`           | `npm install`                    | `yarn add`                       | `yarn add`                 | `pnpm add`                       | `bun add`                          | `deno add --npm`                       |
+| `ni remove <pkg>`        | `npm uninstall`                  | `yarn remove`                    | `yarn remove`              | `pnpm remove`                    | `bun remove`                       | `deno uninstall`                       |
+| `ni run <script>`        | `npm run`                        | `yarn run`                       | `yarn run`                 | `pnpm run`                       | `bun run`                          | `deno run`                             |
+| `ni test`                | `npm run test`                   | `yarn run test`                  | `yarn run test`            | `pnpm run test`                  | `bun run test`                     | `deno run test`                        |
+| `ni upgrade`             | `npm upgrade`                    | `yarn upgrade`                   | `yarn up`                  | `pnpm update`                    | `bun update`                       | `deno outdated --update`               |
+| `ni upgrade-interactive` | `npm-check`**^1**                | `yarn up --interactive "*"`      | `yarn upgrade-interactive` | `pnpm update -i`                 | ○                                  | `deno outdated --update --interactive` |
+| `ni exec <command>`      | `npm exec --no`                  | `yarn <command>`                 | `yarn exec`                | `pnpm exec`                      | `bunx`                             | ○                                      |
+| `ni dlx <pkg>`           | `npx`                            | `npx`                            | `yarn dlx`                 | `pnpm dlx`                       | `bunx`                             | `deno x`                               |
 
 - **^1**: require [npm-check](https://github.com/dylang/npm-check) globally.
 

--- a/ni.zsh
+++ b/ni.zsh
@@ -193,6 +193,10 @@ function ni() {
         shift
         ni-dlx $@
         ;;
+      ci)
+        shift
+        ni-ci $@
+        ;;
       *)
         echo "Unknown subcommand: $1"
         ;;
@@ -432,7 +436,7 @@ function ni-remove(){
 ## yarn exec envinfo
 ## pnpm exec envinfo
 ## bunx envinfo
-## [ ] deno 
+## [ ] deno
 function ni-exec(){
   local manager
   manager=$(ni-getPackageManager)
@@ -493,6 +497,39 @@ function ni-dlx(){
   esac
 }
 
+# ni ci - install with frozen lockfile (equivalent to npm ci)
+# $ ni ci
+## npm ci
+## yarn install --frozen-lockfile (Yarn 1)
+## yarn install --immutable (Yarn Berry)
+## pnpm install --frozen-lockfile
+## bun install --frozen-lockfile
+## deno install --frozen
+function ni-ci(){
+  local manager
+  manager=$(ni-getPackageManager)
+  case $manager in
+    npm)
+      ni-echoRun npm ci
+      ;;
+    yarn)
+      ni-echoRun yarn install --frozen-lockfile
+      ;;
+    yarn-berry)
+      ni-echoRun yarn install --immutable
+      ;;
+    pnpm)
+      ni-echoRun pnpm install --frozen-lockfile
+      ;;
+    bun)
+      ni-echoRun bun install --frozen-lockfile
+      ;;
+    deno)
+      ni-echoRun deno install --frozen
+      ;;
+  esac
+}
+
 
 # auto completion
 function _ni(){
@@ -521,6 +558,7 @@ function _ni(){
         'remove:remove package'
         'exec:execute command'
         'dlx:download package and execute command'
+        'ci:install with frozen lockfile'
       )
       _describe -t subcommands 'subcommands' subcommands
       ;;


### PR DESCRIPTION
## Add `ni ci` command for frozen lockfile installation

This PR implements the equivalent of [`ni --frozen`](https://github.com/antfu-collective/ni?tab=readme-ov-file#ni---install) from the original `ni` project.

### Implementation

Since this project uses the first argument to switch between subcommands (like `ni add`, `ni run`, etc.), I implemented this as the `ni ci` subcommand, following the same pattern as `npm ci`.

### Supported Commands

The `ni ci` command maps to the following package manager-specific commands:

- **npm**: `npm ci`
- **yarn** (v1): `yarn install --frozen-lockfile`
- **yarn-berry** (v2+): `yarn install --immutable`
- **pnpm**: `pnpm install --frozen-lockfile`
- **bun**: `bun install --frozen-lockfile`
- **deno**: `deno install --frozen`
